### PR TITLE
Add ghostwriter server extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rsp-jupyter-extensions",
-    "version": "0.12.0",
+    "version": "0.13.0",
     "description": "Jupyter Extensions for the Rubin Science Platform",
     "keywords": [
         "jupyter",

--- a/rsp_jupyter_extensions/__init__.py
+++ b/rsp_jupyter_extensions/__init__.py
@@ -1,8 +1,8 @@
-from .handlers.environment import Environment_handler
-from .handlers.execution import Execution_handler
-from .handlers.ghostwriter import Ghostwriter_handler
-from .handlers.hub import Hub_handler
-from .handlers.query import Query_handler
+from .handlers.environment import EnvironmentHandler
+from .handlers.execution import ExecutionHandler
+from .handlers.ghostwriter import GhostwriterHandler
+from .handlers.hub import HubHandler
+from .handlers.query import QueryHandler
 
 from jupyter_server.utils import url_path_join as ujoin
 
@@ -30,11 +30,11 @@ def _setup_handlers(server_app) -> None:
     """Sets up the route handlers to call the appropriate functionality."""
     web_app = server_app.web_app
     extmap = {
-        r"/rubin/environment": Environment_handler,
-        r"/rubin/execution": Execution_handler,
-        r"/rubin/ghostwriter($|/$|/.*)": Ghostwriter_handler,
-        r"/rubin/hub": Hub_handler,
-        r"/rubin/query": Query_handler,
+        r"/rubin/environment": EnvironmentHandler,
+        r"/rubin/execution": ExecutionHandler,
+        r"/rubin/ghostwriter($|/$|/.*)": GhostwriterHandler,
+        r"/rubin/hub": HubHandler,
+        r"/rubin/query": QueryHandler,
     }
 
     # add the baseurl to our paths...

--- a/rsp_jupyter_extensions/__init__.py
+++ b/rsp_jupyter_extensions/__init__.py
@@ -1,5 +1,6 @@
 from .handlers.environment import Environment_handler
 from .handlers.execution import Execution_handler
+from .handlers.ghostwriter import Ghostwriter_handler
 from .handlers.hub import Hub_handler
 from .handlers.query import Query_handler
 
@@ -31,6 +32,7 @@ def _setup_handlers(server_app) -> None:
     extmap = {
         r"/rubin/environment": Environment_handler,
         r"/rubin/execution": Execution_handler,
+        r"/rubin/ghostwriter($|/$|/.*)": Ghostwriter_handler,
         r"/rubin/hub": Hub_handler,
         r"/rubin/query": Query_handler,
     }

--- a/rsp_jupyter_extensions/handlers/environment.py
+++ b/rsp_jupyter_extensions/handlers/environment.py
@@ -7,7 +7,7 @@ import tornado
 from jupyter_server.base.handlers import JupyterHandler
 
 
-class Environment_handler(JupyterHandler):
+class EnvironmentHandler(JupyterHandler):
     """
     Environment Handler.  Return the JSON representation of our OS environment
     settings.

--- a/rsp_jupyter_extensions/handlers/execution.py
+++ b/rsp_jupyter_extensions/handlers/execution.py
@@ -14,7 +14,7 @@ from nbconvert.preprocessors import CellExecutionError
 NBFORMAT_VERSION = 4
 
 
-class Execution_handler(JupyterHandler):
+class ExecutionHandler(JupyterHandler):
     """
     RSP templated Execution Handler.
     """

--- a/rsp_jupyter_extensions/handlers/ghostwriter.py
+++ b/rsp_jupyter_extensions/handlers/ghostwriter.py
@@ -1,0 +1,43 @@
+"""Ghostwriter handler, used for redirection bank shots once you've
+started a new lab."""
+from jupyter_server.base.handlers import JupyterHandler
+
+
+class Ghostwriter_handler(JupyterHandler):
+    """
+    Ghostwriter handler.  Used to handle the case where Ghostwriter runs
+    ensure_lab and no lab is running: the original redirection is
+    changed to point at this endpoint within the lab, and this just
+    issues the redirect back to the root path.  But this time, enable_lab
+    will realize the lab is indeed running, and the rest of the flow will
+    proceed.
+
+    All of this can happen in prepare(), because we don't care what method
+    it is.
+    """
+
+    def prepare(self) -> None:
+        self.redirect(self._peel_route())
+
+    def _peel_route(self) -> None:
+        """Return the stuff after '/rubin/ghostwriter' as the top-level
+        path.  This will send the requestor back to the original location,
+        where this time, the running_lab check will succeed and they will
+        wind up where they should."""
+        bad_route = "/nb"  # In case of failure, dump to lab?  I guess?
+        path = self.request.path
+        self.log.info(f"Ghostwriter method '{self.request.method}'," f" path '{path}'")
+        stem = "/rubin/ghostwriter/"
+        pos = path.find(stem)
+        if pos == -1:
+            # We didn't match.
+            return bad_route
+        idx = len(stem) + pos - 1
+        redir = path[idx:]
+        if redir.startswith(stem):
+            # This is gonna be a redirect loop.
+            return bad_route
+        if not redir or redir == "/":
+            # Rather than landing us at the root of the RSP instance.
+            return bad_route
+        return redir

--- a/rsp_jupyter_extensions/handlers/ghostwriter.py
+++ b/rsp_jupyter_extensions/handlers/ghostwriter.py
@@ -34,10 +34,10 @@ class GhostwriterHandler(JupyterHandler):
             return bad_route
         idx = len(stem) + pos - 1
         redir = path[idx:]
-        if redir.startswith(stem):
-            # This is gonna be a redirect loop.
-            return bad_route
-        if not redir or redir == "/":
-            # Rather than landing us at the root of the RSP instance.
+        if not redir or redir == "/" or redir.startswith(stem):
+            self.log.warning(
+                f"Request for bad redirection '{redir}';"
+                f" returning '{bad_route}' instead"
+            )
             return bad_route
         return redir

--- a/rsp_jupyter_extensions/handlers/ghostwriter.py
+++ b/rsp_jupyter_extensions/handlers/ghostwriter.py
@@ -3,7 +3,7 @@ started a new lab."""
 from jupyter_server.base.handlers import JupyterHandler
 
 
-class Ghostwriter_handler(JupyterHandler):
+class GhostwriterHandler(JupyterHandler):
     """
     Ghostwriter handler.  Used to handle the case where Ghostwriter runs
     ensure_lab and no lab is running: the original redirection is

--- a/rsp_jupyter_extensions/handlers/hub.py
+++ b/rsp_jupyter_extensions/handlers/hub.py
@@ -7,7 +7,7 @@ from jupyter_server.base.handlers import JupyterHandler
 from jupyter_server.utils import url_path_join as ujoin
 
 
-class Hub_handler(JupyterHandler):
+class HubHandler(JupyterHandler):
     """
     Hub Handler.  Currently all we do is DELETE (to shut down a running Lab
     instance) but we could extend this to do anything in the Hub REST API.

--- a/rsp_jupyter_extensions/handlers/query.py
+++ b/rsp_jupyter_extensions/handlers/query.py
@@ -20,7 +20,7 @@ class UnimplementedQueryResolutionError(Exception):
     pass
 
 
-class Query_handler(JupyterHandler):
+class QueryHandler(JupyterHandler):
     """
     RSP templated Query Handler.
     """


### PR DESCRIPTION
Add `/rubin/ghostwriter` so that in the case where Ghostwriter redirects you to the Lab, but it isn't running yet, we can intercept that in `ensure_lab` and send the user through the Hub spawner, with the path pointing to the Ghostwriter extension.

Then once that lab is running, we can redirect the user back to the original request, which will come through `ensure_lab` again, find that the lab *is* running, and continue on through the rest of the rewriting to land the user at the correct redirected page.