### PR TITLE
DM-48733: Use new endpoint for rendering Times Square notebook templates

### DIFF
--- a/rsp_jupyter_extensions/handlers/query.py
+++ b/rsp_jupyter_extensions/handlers/query.py
@@ -112,13 +112,7 @@ class QueryHandler(APIHandler):
         params: dict[str, str],
     ) -> str:
         """Ask times-square for a rendered notebook."""
-        # Since we know the path we don't have to crawl the base github
-        # response.
-        nb_url = f"github/{org}/{repo}/{directory}/{notebook}"
-
-        # Get the endpoint for the rendered URL
-        obj = self._ts_client.get(nb_url).json()
-        rendered_url = obj["rendered_url"]
+        rendered_url = f"github/rendered/{org}/{repo}/{directory}/{notebook}"
 
         # Retrieve that URL and return the textual response, which is the
         # string representing the rendered notebook "in unicode", which


### PR DESCRIPTION
This will let us nublado access the template rendering functionality (that the 'Open from portal query URL' option uses) through a different ingress than other Times Square endpoints, and allow users to access it who do not have access to the notebook execution parts of Times Square.

We should wait to merge/release this until after [Times Square 0.17.0](https://github.com/lsst-sqre/times-square/pull/93) is released.