### PR TITLE
tickets/DM-49490: Rollup for user domain support and lab startup hardening

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ help:
 .PHONY: init
 init:
 	pip install --upgrade uv
-	uv pip install --editable '.[test]'
+	uv pip install --editable '.[test]' jupyterlab
 	pre-commit install
 
 .PHONY: typing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rsp_jupyter_extensions
 
-[![Github Actions Status](https://github.com/lsst-sqre/rsp-jupyter-extensions /workflows/Build/badge.svg)](https://github.com/lsst-sqre/rsp-jupyter-extensions /actions/workflows/build.yml)
+[![Github Actions Status](https://github.com/lsst-sqre/rsp-jupyter-extensions/workflows/CI/badge.svg)](https://github.com/lsst-sqre/rsp-jupyter-extensions/actions/workflows/ci.yaml)
 Jupyter Extensions for the Rubin Science Platform
 
 This extension is composed of a Python package named `rsp_jupyter_extensions`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rsp-jupyter-extensions",
-    "version": "0.15.0",
+    "version": "0.16.0",
     "description": "Jupyter Extensions for the Rubin Science Platform",
     "keywords": [
         "jupyter",

--- a/rsp_jupyter_extensions/handlers/ghostwriter.py
+++ b/rsp_jupyter_extensions/handlers/ghostwriter.py
@@ -34,7 +34,10 @@ class GhostwriterHandler(JupyterHandler):
         #
         # So once we're at Python 3.13, we can remove that type: ignore.
         redir = _peel_route(self.request.path, "/rubin/ghostwriter")
-        ext_url = os.getenv("EXTERNAL_INSTANCE_URL", "http://localhost:8888")
+        # If we don't have EXTERNAL_INSTANCE_URL, we don't have ghostwriter.
+        # Just crash the handler, I guess?  It'll look like a no-op to the
+        # user with some nastiness in the browser console.
+        ext_url = os.environ["EXTERNAL_INSTANCE_URL"]
         if redir:
             # We want to go all the way back out to the top level and
             # hit the external ghostwriter redirect again.

--- a/rsp_jupyter_extensions/handlers/ghostwriter.py
+++ b/rsp_jupyter_extensions/handlers/ghostwriter.py
@@ -2,6 +2,9 @@
 started a new lab.
 """
 
+import os
+from urllib.parse import urljoin
+
 from jupyter_server.base.handlers import JupyterHandler
 
 from ._utils import _peel_route
@@ -9,12 +12,12 @@ from ._utils import _peel_route
 
 class GhostwriterHandler(JupyterHandler):
     """
-    Ghostwriter handler.  Used to handle the case where Ghostwriter runs
-    ensure_lab and no lab is running: the original redirection is
-    changed to point at this endpoint within the lab, and this just
-    issues the redirect back to the root path.  But this time, enable_lab
-    will realize the lab is indeed running, and the rest of the flow will
-    proceed.
+    Used to handle the case where Ghostwriter runs ensure_lab and no
+    lab is running: the original redirection is changed to point at
+    this endpoint within the lab, and this just issues the redirect
+    back to the external Ghostwriter-managed root path.  But this
+    time, enable_lab will realize the lab is indeed running, and the
+    rest of the flow will proceed.
 
     All of this can happen in prepare(), because we don't care what method
     it is.
@@ -28,12 +31,20 @@ class GhostwriterHandler(JupyterHandler):
         """Issue a redirect based on the request path."""
         # the implicit None return can also function as a null coroutine,
         # and in Python 3.13, "None" becomes a valid return type from it.
+        #
+        # So once we're at Python 3.13, we can remove that type: ignore.
         redir = _peel_route(self.request.path, "/rubin/ghostwriter")
+        ext_url = os.getenv("EXTERNAL_INSTANCE_URL", "http://localhost:8888")
         if redir:
-            self.redirect(redir)
+            # We want to go all the way back out to the top level and
+            # hit the external ghostwriter redirect again.
+            self.redirect(urljoin(ext_url, redir))
         else:
             self.log.warning(
                 f"Cannot strip '/rubin/ghostwriter' from '{self.request.path}'"
-                f" ; returning '/nb' instead"
+                f" ; returning a redirection to the Hub instead"
             )
-            self.redirect("/nb")
+            # $JUPYTERHUB_PUBLIC_HUB_URL is unset if user domains are not
+            # enabled, and therefore "/nb" will point us to the Hub...
+            # and the Hub will drop us back in the running Lab.
+            self.redirect(os.getenv("JUPYTERHUB_PUBLIC_HUB_URL", "/nb"))

--- a/src/abnormal.ts
+++ b/src/abnormal.ts
@@ -50,12 +50,18 @@ function getDialogBody(env: IEnvResponse): string {
 }
 
 function getSupplementalBody(errno: number): string {
+  const no_trust = ' This Lab should not be trusted for work you want to keep.';
   const no_storage =
     'You have run out of storage space. Try deleting unneeded .user_env directories and no-longer relevant large files, then shut down and restart the Lab.';
   const no_permission =
-    'You do not have permission to write.  Ask your RSP site administrator to check ownership and permissions on your directories.';
+    'You do not have permission to write. Ask your RSP site administrator to check ownership and permissions on your directories.' +
+    no_trust;
   const no_idea =
-    'Please open an issue with your RSP site administrator with the error number, description, and message shown above.';
+    'Please open an issue with your RSP site administrator with the error number, description, and message shown above.' +
+    no_trust;
+  const no_environment =
+    'You are missing environment variables necessary for RSP operation. ' +
+    no_idea;
   switch (errno) {
     case 13:
       return no_permission;
@@ -65,6 +71,9 @@ function getSupplementalBody(errno: number): string {
       break;
     case 30:
       return no_permission;
+      break;
+    case 104:
+      return no_environment;
       break;
     case 122:
       return no_storage;

--- a/src/abnormal.ts
+++ b/src/abnormal.ts
@@ -45,29 +45,32 @@ function getDialogBody(env: IEnvResponse): string {
     msg = env.ABNORMAL_STARTUP_MESSAGE;
   }
   let body = `JupyterLab is running in degraded mode: error # ${errno} [${strerror}] "${msg}"`;
-  body = body + '\n\n' + getSupplementalBody(errno)
-  return body
+  body = body + '\n\n' + getSupplementalBody(errno);
+  return body;
 }
 
 function getSupplementalBody(errno: number): string {
-  const no_storage = 'You have run out of storage space. Try deleting unneeded .user_env directories and no-longer relevant large files, then shut down and restart the Lab.'
-  const no_permission = 'You do not have permission to write.  Ask your RSP site administrator to check ownership and permissions on your directories.';
-  const no_idea = 'Please open an issue with your RSP site administrator with the error number, description, and message shown above.';
+  const no_storage =
+    'You have run out of storage space. Try deleting unneeded .user_env directories and no-longer relevant large files, then shut down and restart the Lab.';
+  const no_permission =
+    'You do not have permission to write.  Ask your RSP site administrator to check ownership and permissions on your directories.';
+  const no_idea =
+    'Please open an issue with your RSP site administrator with the error number, description, and message shown above.';
   switch (errno) {
-  case 13:
-    return no_permission;
-    break;
-  case 28:
-    return no_storage;
-    break;
-  case 30:
-    return no_permission;
-    break;
-  case 122:
-    return no_storage;
-    break;
-  default:
-    return no_idea;
-    break;
+    case 13:
+      return no_permission;
+      break;
+    case 28:
+      return no_storage;
+      break;
+    case 30:
+      return no_permission;
+      break;
+    case 122:
+      return no_storage;
+      break;
+    default:
+      return no_idea;
+      break;
   }
 }

--- a/src/abnormal.ts
+++ b/src/abnormal.ts
@@ -36,6 +36,11 @@ function getDialogBody(env: IEnvResponse): string {
   if (env.ABNORMAL_STARTUP_ERRNO) {
     errno = parseInt(env.ABNORMAL_STARTUP_ERRNO);
   }
+  let errorcode = 'EUNKNOWN';
+  if (env.ABNORMAL_STARTUP_ERRORCODE) {
+    errorcode = env.ABNORMAL_STARTUP_ERRORCODE;
+  }
+
   let strerror = 'unknown error';
   if (env.ABNORMAL_STARTUP_STRERROR) {
     strerror = env.ABNORMAL_STARTUP_STRERROR;
@@ -44,12 +49,12 @@ function getDialogBody(env: IEnvResponse): string {
   if (env.ABNORMAL_STARTUP_MESSAGE) {
     msg = env.ABNORMAL_STARTUP_MESSAGE;
   }
-  let body = `JupyterLab is running in degraded mode: error # ${errno} [${strerror}] "${msg}"`;
-  body = body + '\n\n' + getSupplementalBody(errno);
+  let body = `JupyterLab is running in degraded mode: error # ${errno} (${errorcode}) [${strerror}] "${msg}"`;
+  body = body + '\n\n' + getSupplementalBody(errorcode);
   return body;
 }
 
-function getSupplementalBody(errno: number): string {
+function getSupplementalBody(errorcode: string): string {
   const no_trust = ' This Lab should not be trusted for work you want to keep.';
   const no_storage =
     'You have run out of storage space. Try deleting unneeded .user_env directories and no-longer relevant large files, then shut down and restart the Lab.';
@@ -62,21 +67,21 @@ function getSupplementalBody(errno: number): string {
   const no_environment =
     'You are missing environment variables necessary for RSP operation. ' +
     no_idea;
-  switch (errno) {
-    case 13:
+  switch (errorcode) {
+    case 'EACCES':
       return no_permission;
       break;
-    case 28:
+    case 'ENOSPC':
       return no_storage;
       break;
-    case 30:
+    case 'EROFS':
       return no_permission;
       break;
-    case 104:
+    case 'EDQUOT':
+      return no_storage;
+      break;
+    case 'EBADENV':
       return no_environment;
-      break;
-    case 122:
-      return no_storage;
       break;
     default:
       return no_idea;

--- a/src/abnormal.ts
+++ b/src/abnormal.ts
@@ -1,0 +1,73 @@
+import { showDialog, Dialog } from '@jupyterlab/apputils';
+import { IEnvResponse } from './environment';
+import { LogLevels, logMessage } from './logger';
+
+export async function abnormalDialog(env: IEnvResponse): Promise<void> {
+  const options = {
+    title: 'Degraded Mode',
+    body: getDialogBody(env),
+    focusNodeSelector: 'input',
+    buttons: [Dialog.warnButton({ label: 'OK' })]
+  };
+  try {
+    const result = await showDialog(options);
+    if (!result) {
+      logMessage(LogLevels.DEBUG, env, 'No result from queryDialog');
+      return;
+    }
+    logMessage(LogLevels.DEBUG, env, `Result from queryDialog: ${result}`);
+    if (!result.value) {
+      logMessage(LogLevels.DEBUG, env, 'No result.value from queryDialog');
+      return;
+    }
+    if (!result.button) {
+      logMessage(LogLevels.DEBUG, env, 'No result.button from queryDialog');
+      return;
+    }
+    return;
+  } catch (error) {
+    console.error(`Error showing abnormal startup dialog ${error}`);
+    throw new Error(`Failed to show abnormal startup dialog: ${error}`);
+  }
+}
+
+function getDialogBody(env: IEnvResponse): string {
+  let errno = -1;
+  if (env.ABNORMAL_STARTUP_ERRNO) {
+    errno = parseInt(env.ABNORMAL_STARTUP_ERRNO);
+  }
+  let strerror = 'unknown error';
+  if (env.ABNORMAL_STARTUP_STRERROR) {
+    strerror = env.ABNORMAL_STARTUP_STRERROR;
+  }
+  let msg = '???';
+  if (env.ABNORMAL_STARTUP_MESSAGE) {
+    msg = env.ABNORMAL_STARTUP_MESSAGE;
+  }
+  let body = `JupyterLab is running in degraded mode: error # ${errno} [${strerror}] "${msg}"`;
+  body = body + '\n\n' + getSupplementalBody(errno)
+  return body
+}
+
+function getSupplementalBody(errno: number): string {
+  const no_storage = 'You have run out of storage space. Try deleting unneeded .user_env directories and no-longer relevant large files, then shut down and restart the Lab.'
+  const no_permission = 'You do not have permission to write.  Ask your RSP site administrator to check ownership and permissions on your directories.';
+  const no_idea = 'Please open an issue with your RSP site administrator with the error number, description, and message shown above.';
+  switch (errno) {
+  case 13:
+    return no_permission;
+    break;
+  case 28:
+    return no_storage;
+    break;
+  case 30:
+    return no_permission;
+    break;
+  case 122:
+    return no_storage;
+    break;
+  default:
+    return no_idea;
+    break;
+  }
+}

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -5,6 +5,10 @@ import { apiRequest, IJSONResponse } from './request';
 // IEnvResponse encapsulates the environment variables we
 // care about.  It's always a string-to-string mapping.
 interface IEnvResponse {
+  ABNORMAL_STARTUP?: string;
+  ABNORMAL_STARTUP_ERRNO?: string;
+  ABNORMAL_STARTUP_STRERROR?: string;
+  ABNORMAL_STARTUP_MESSAGE?: string;
   IMAGE_DESCRIPTION?: string;
   IMAGE_DIGEST?: string;
   JUPYTER_IMAGE_SPEC?: string;

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -6,6 +6,7 @@ import { apiRequest, IJSONResponse } from './request';
 // care about.  It's always a string-to-string mapping.
 interface IEnvResponse {
   ABNORMAL_STARTUP?: string;
+  ABNORMAL_STARTUP_ERRORCODE?: string;
   ABNORMAL_STARTUP_ERRNO?: string;
   ABNORMAL_STARTUP_STRERROR?: string;
   ABNORMAL_STARTUP_MESSAGE?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,8 @@ import { activateRSPTutorialsExtension } from './tutorials';
 
 import { logMessage, LogLevels } from './logger';
 
+import { abnormalDialog } from './abnormal';
+
 import * as token from './tokens';
 
 function activateRSPExtension(
@@ -38,6 +40,13 @@ function activateRSPExtension(
     );
     logMessage(LogLevels.INFO, env, '...got server environment');
     logMessage(LogLevels.INFO, env, 'rsp-lab-extension: loading...');
+    logMessage(LogLevels.INFO, env, '...activating savequit extension...');
+    activateRSPSavequitExtension(app, mainMenu, docManager, env);
+    logMessage(LogLevels.INFO, env, '...checking for abnormal startup...');
+    if (env.ABNORMAL_STARTUP === 'TRUE') {
+      // Give the user a warning dialog
+      abnormalDialog(env);
+    }
     logMessage(
       LogLevels.INFO,
       env,

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,8 +65,6 @@ function activateRSPExtension(
         `...skipping query extension because site type is '${env.RSP_SITE_TYPE}'...`
       );
     }
-    logMessage(LogLevels.INFO, env, '...activating savequit extension...');
-    activateRSPSavequitExtension(app, mainMenu, docManager, env);
     logMessage(LogLevels.INFO, env, '...activated...');
     logMessage(LogLevels.INFO, env, '...activating tutorials extension...');
     if (env.RSP_SITE_TYPE === 'science') {

--- a/src/savequit.ts
+++ b/src/savequit.ts
@@ -172,9 +172,9 @@ function justQuit(
   env: IEnvResponse
 ): Promise<any> {
   infoDialog(env);
-  let targetEndpoint = '/';
+  let targetEndpoint = `${env.EXTERNAL_INSTANCE_URL}`
   if (logout) {
-    targetEndpoint = '/logout';
+    targetEndpoint = targetEndpoint + '/logout';
   }
   return Promise.resolve(
     hubDeleteRequest(app, env)

--- a/src/savequit.ts
+++ b/src/savequit.ts
@@ -172,7 +172,7 @@ function justQuit(
   env: IEnvResponse
 ): Promise<any> {
   infoDialog(env);
-  let targetEndpoint = `${env.EXTERNAL_INSTANCE_URL}`
+  let targetEndpoint = `${env.EXTERNAL_INSTANCE_URL}`;
   if (logout) {
     targetEndpoint = targetEndpoint + '/logout';
   }

--- a/ui-tests/tests/rsp_jupyter_extensions.spec.ts
+++ b/ui-tests/tests/rsp_jupyter_extensions.spec.ts
@@ -15,7 +15,9 @@ test('should emit an activation console message', async ({ page }) => {
 
   await page.goto();
 
-  expect(logs.filter(s => s === '...loaded rsp-lab-extension.')).toHaveLength(
-    1
-  );
+  // No, don't know why this suddenly stopped working.  It's clearly visible
+  // in the console output when you run it.
+
+  // expect(logs.filter(
+  //          s => s === '...loaded rsp-lab-extension.')).toHaveLength(1);
 });

--- a/ui-tests/tests/rsp_jupyter_extensions.spec.ts
+++ b/ui-tests/tests/rsp_jupyter_extensions.spec.ts
@@ -15,9 +15,7 @@ test('should emit an activation console message', async ({ page }) => {
 
   await page.goto();
 
-  // No, don't know why this suddenly stopped working.  It's clearly visible
-  // in the console output when you run it.
-
-  // expect(logs.filter(
-  //          s => s === '...loaded rsp-lab-extension.')).toHaveLength(1);
+  expect(logs.filter(s => s === '...loaded rsp-lab-extension.')).toHaveLength(
+    1
+  );
 });


### PR DESCRIPTION
This rolls up several changes needed for robustness as we move towards DP1.

* If the Lab starts with `ABNORMAL_STARTUP` env vars set, interrupt startup with a modal dialog informing the user and (in some cases) suggesting corrective action.
* Correct Ghostwriter and the Quit extensions to be user-domain aware and do the right thing in that case.
* Ensure that Jupyter Lab is present in the development environment.