### PR TITLE
DM-51011: Fix setting `kernel_name` when None

### DIFF
--- a/rsp_jupyter_extensions/handlers/execution.py
+++ b/rsp_jupyter_extensions/handlers/execution.py
@@ -63,9 +63,13 @@ class ExecutionHandler(APIHandler):
             resources = None
             nb_str = input_str
         nb = nbformat.reads(nb_str, NBFORMAT_VERSION)
-        executor = nbconvert.preprocessors.ExecutePreprocessor(
-            kernel_name=kernel_name
-        )
+        if kernel_name is not None:
+            executor = nbconvert.preprocessors.ExecutePreprocessor(
+                kernel_name=kernel_name
+            )
+        else:
+            # If kernel_name is None, don't set it to avoid TraitError
+            executor = nbconvert.preprocessors.ExecutePreprocessor()
         exporter = nbconvert.exporters.NotebookExporter()
 
         #    a1fec27fec84514e83780d524766d9f74e4bb2e3/nbconvert/\

--- a/rsp_jupyter_extensions/tests/execution_test.py
+++ b/rsp_jupyter_extensions/tests/execution_test.py
@@ -185,4 +185,4 @@ async def test_execution_handler_post_no_kernel_name(
 
     assert response.code == 200
     mock_class, _ = mock_executor
-    mock_class.assert_called_once_with(kernel_name=None)
+    mock_class.assert_called_once_with()


### PR DESCRIPTION
I found out (and my mistake for not testing this in dev) that ExecutePreprocessor uses Traitlets to validate arguments at runtime, and setting kernel_name to None to get the default doesn't work; we need to simply not set kernel_name. This is the most pragmatic solution: simply making two separate calls to ExecutePreprocessor. If we have more arguments, we could switch to building an arguments dict.