### PR TITLE
Allow filebrowser/jupyter_server root to not be $HOME

### DIFF
--- a/rsp_jupyter_extensions/__init__.py
+++ b/rsp_jupyter_extensions/__init__.py
@@ -51,7 +51,8 @@ def _setup_handlers(server_app) -> None:  # type: ignore
     base_url = web_app.settings["base_url"]
     # And now add the handlers.
     handlers = [(ujoin(base_url, x), extmap[x]) for x in extmap]
-    server_app.log.info(f"RJE Handlers: {handlers}")
+    hnames = [(ujoin(base_url, x), extmap[x].__name__) for x in extmap]
+    server_app.log.info(f"RJE Handlers: {hnames}")
     web_app.add_handlers(host_pattern, handlers)
 
 

--- a/rsp_jupyter_extensions/handlers/_utils.py
+++ b/rsp_jupyter_extensions/handlers/_utils.py
@@ -26,7 +26,12 @@ def _write_notebook_response(nb_text: str, target: Path) -> str:
     """
     dirname = target.parent
     fname = target.name
-    rname = target.relative_to(Path(os.getenv("JUPYTER_SERVER_ROOT", "")))
+    # JUPYTER_SERVER_ROOT is set *by* JupyterLab, not in its environment.
+    filebrowser_setting = os.getenv("FILE_BROWSER_ROOT", "home")
+    if filebrowser_setting == "root":
+        rname = target.relative_to(Path("/"))
+    else:
+        rname = target.relative_to(Path(os.getenv("HOME", "")))
     dirname.mkdir(parents=True, exist_ok=True)
     target.write_text(nb_text)
     top = os.environ.get("JUPYTERHUB_SERVICE_PREFIX", "")

--- a/rsp_jupyter_extensions/handlers/_utils.py
+++ b/rsp_jupyter_extensions/handlers/_utils.py
@@ -4,6 +4,24 @@ import json
 import os
 from pathlib import Path
 
+from ..models.tutorials import UserEnvironmentError
+
+
+def _get_homedir() -> Path:
+    homedir = os.getenv("HOME")
+    if not homedir:
+        raise UserEnvironmentError("home directory is not set")
+    return Path(homedir)
+
+
+def _get_jupyter_server_root() -> Path:
+    # We can't use JUPYTER_SERVER_ROOT, as it's set by the JupyterLab process
+    # for the subprocesses it spawns, but not in the parent process.
+    srv_root = os.getenv("FILEBROWSER_ROOT", "home")
+    if srv_root == "root":
+        return Path("/")
+    return _get_homedir()
+
 
 def _peel_route(path: str, stem: str) -> str | None:
     # Return the part of the route after the stem, or None if that doesn't
@@ -27,11 +45,7 @@ def _write_notebook_response(nb_text: str, target: Path) -> str:
     dirname = target.parent
     fname = target.name
     # JUPYTER_SERVER_ROOT is set *by* JupyterLab, not in its environment.
-    filebrowser_setting = os.getenv("FILE_BROWSER_ROOT", "home")
-    if filebrowser_setting == "root":
-        rname = target.relative_to(Path("/"))
-    else:
-        rname = target.relative_to(Path(os.getenv("HOME", "")))
+    rname = target.relative_to(_get_jupyter_server_root())
     dirname.mkdir(parents=True, exist_ok=True)
     target.write_text(nb_text)
     top = os.environ.get("JUPYTERHUB_SERVICE_PREFIX", "")

--- a/rsp_jupyter_extensions/handlers/pdfexport.py
+++ b/rsp_jupyter_extensions/handlers/pdfexport.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import tornado
 from jupyter_server.base.handlers import APIHandler
 
+from ._utils import _get_jupyter_server_root
+
 
 @dataclass
 class PDFExportResponse:
@@ -53,11 +55,7 @@ class PDFExportHandler(APIHandler):
     def initialize(self) -> None:
         """Set rootdir."""
         super().initialize()
-        filebrowser_setting = os.getenv("FILEBROWSER_ROOT", "home")
-        if filebrowser_setting == "root":
-            self._root_dir = Path("/")
-        else:
-            self._root_dir = Path(os.getenv("HOME", ""))
+        self._root_dir = _get_jupyter_server_root()
 
     @tornado.web.authenticated
     async def post(self, *args: str, **kwargs: str) -> None:

--- a/rsp_jupyter_extensions/handlers/pdfexport.py
+++ b/rsp_jupyter_extensions/handlers/pdfexport.py
@@ -53,17 +53,19 @@ class PDFExportHandler(APIHandler):
     def initialize(self) -> None:
         """Set rootdir."""
         super().initialize()
-        self._root_dir = Path(os.getenv("JUPYTER_SERVER_ROOT", ""))
+        filebrowser_setting = os.getenv("FILEBROWSER_ROOT", "home")
+        if filebrowser_setting == "root":
+            self._root_dir = Path("/")
+        else:
+            self._root_dir = Path(os.getenv("HOME", ""))
 
     @tornado.web.authenticated
     async def post(self, *args: str, **kwargs: str) -> None:
         """POST receives the query type and the query value as a JSON
         object containing "path" key.  It is a string, and should be
         a relative path (that is, should not start with "/" and should
-        expect to be appended to $JUPYTER_SERVER_ROOT (self._rootdir);
-        in the current RSP setup, that's the same as $HOME, but that may
-        change if we figure out how to get jupyter-server-documents and
-        thus collaborative editing stable.
+        expect to be appended to self._root_dir); self._root_dir may be
+        either / or $HOME.
 
         Having resolved the filename, if it exists and the directory
         is writeable, we will change directory to where that file

--- a/rsp_jupyter_extensions/handlers/query.py
+++ b/rsp_jupyter_extensions/handlers/query.py
@@ -32,8 +32,8 @@ class QueryHandler(APIHandler):
         self._ts_client = RSPClient("/times-square/api/v1/")
         self._tap_client = RSPClient("/api/tap/")
         self._dataset_client: dict[str, RSPClient] = {}
-        self._root_dir = Path(os.getenv("JUPYTER_SERVER_ROOT", ""))
-        self._cachefile = self._root_dir / ".cache" / "queries.json"
+        self._home_dir = Path(os.getenv("HOME", ""))
+        self._cachefile = self._home_dir / ".cache" / "queries.json"
         self._initialize_cache()
         self._initialize_dataset_clients()
 
@@ -81,12 +81,12 @@ class QueryHandler(APIHandler):
         of "dataset:jobref_id", referring to that query.
 
         It will then use the value to resolve the template, and
-        construct a filename resolved under $JUPYTER_SERVER_ROOT
-        (self._rootdir, and in the RSP, the same as $HOME).  If that
-        file exists, we will return it, on the grounds that the user
-        has done this particular query before and we want to keep any
+        construct a filename resolved under $HOME.  If that file
+        exists, we will return it, on the grounds that the user has
+        done this particular query before and we want to keep any
         changes made.  Otherwise we will write a file with the query
         template resolved, so the user can run it to retrieve results.
+
         """
         input_str = self.request.body.decode("utf-8")
         input_document = json.loads(input_str)
@@ -136,7 +136,7 @@ class QueryHandler(APIHandler):
             q_id = q_value
             q_ds = "tap"
         fname = (
-            self._root_dir / "notebooks" / "queries" / f"{q_ds}_{q_id}.ipynb"
+            self._home_dir / "notebooks" / "queries" / f"{q_ds}_{q_id}.ipynb"
         )
         if fname.is_file():
             nb = fname.read_text()
@@ -272,7 +272,7 @@ class QueryHandler(APIHandler):
     async def _generate_query_all_notebook(self) -> str:
         output = await self._get_query_all_notebook()
         fname = (
-            self._root_dir
+            self._home_dir
             / "notebooks"
             / "queries"
             / "tap_query_history.ipynb"

--- a/rsp_jupyter_extensions/handlers/tutorials.py
+++ b/rsp_jupyter_extensions/handlers/tutorials.py
@@ -27,6 +27,7 @@ from ..models.tutorials import (
     TagError,
     UserEnvironmentError,
 )
+from ._utils import _get_homedir, _get_jupyter_server_root
 
 # _find_repo and _get_tag might belong in lsst.rsp.
 
@@ -80,20 +81,6 @@ def _clone_repo(repo_url: str, branch: str, dirname: str) -> None:
         raise RuntimeError(f"git clone {repo_url}@{branch} failed")
 
 
-def _get_homedir() -> Path:
-    homedir = os.getenv("HOME")
-    if not homedir:
-        raise UserEnvironmentError("home directory is not set")
-    return Path(homedir)
-
-
-def _get_jupyter_server_root() -> Path:
-    srv_root = os.getenv("FILEBROWSER_ROOT", "home")
-    if srv_root == "root":
-        return Path("/")
-    return _get_homedir()
-
-
 # RSP-specific tutorial locations
 
 
@@ -141,12 +128,13 @@ def _reabsolutize_path(path: Path) -> Path:
     if path.is_absolute():
         return path
     # We need to re-absolutize it so it doesn't get written to wherever
-    # the Lab extension is running from.
+    # the Lab extension is running from.  If it is relative, it's relative
+    # to the Jupyter Server root, which might be $HOME or might be /.
     root_dir = _get_jupyter_server_root()
     return root_dir / path
 
 
-def _copy_content(entry: HierarchyEntry) -> None:
+def _copy_content(entry: HierarchyEntry, dest: Path) -> None:
     # Note that we assume we've already decided we want to do this (that is,
     # the check for Disposition and a file conflict has already happened).
     #
@@ -157,7 +145,10 @@ def _copy_content(entry: HierarchyEntry) -> None:
     #
     # Relative paths are relative to either / or $HOME, depending on
     # $FILEBROWSER_ROOT setting (in turn, a Phalanx setting).
-    dest = _reabsolutize_path(entry.dest)
+    #
+    # Note that because of the above, entry.dest has different meanings
+    # depending on the setting; rather than recalculating, we just pass
+    # the updated path from the caller.
     dest.parent.mkdir(exist_ok=True, parents=True)
     if entry.action == Actions.FETCH:
         if not isinstance(entry.src, str):
@@ -188,15 +179,23 @@ def _check_containment(dest: Path) -> None:
 
 def _get_notebook_path(dest: Path) -> str:
     root_dir = _get_jupyter_server_root()
-    if dest.is_absolute():
-        return str(dest.relative_to(root_dir))
-    return str(dest)
+    abs_dest = _reabsolutize_path(dest)
+    return str(abs_dest.relative_to(root_dir))
 
 
 def _copy_and_guide(input_document: dict[str, Any]) -> _UIGuidance:
     entry = HierarchyEntry.from_primitive(input_document)
-    dest = Path(entry.dest)
-    dest = _reabsolutize_path(dest)
+    # For this extension, the target should always be inside the user's
+    # home directory.  This is a consequence of the RSP design, where
+    # the user is not root within the container, and most of the container
+    # is read-only to the user.
+    destpath = Path(entry.dest)
+    if not destpath.is_absolute():
+        dest = _get_homedir() / destpath
+    else:
+        # This shouldn't happen: dest should have been supplied as a relative
+        # path.  If it isn't, though, assume we know what we're doing.
+        dest = destpath
     _check_containment(dest)
     if dest.exists():
         disposition = entry.disposition
@@ -210,14 +209,13 @@ def _copy_and_guide(input_document: dict[str, Any]) -> _UIGuidance:
         else:
             # Otherwise, just fall through and overwrite the file.
             pass
-    _copy_content(entry)
+    _copy_content(entry, dest)  # Dest path may have changed.
     # We don't want to issue the redirect, because we don't want to
     # mess with opening a new window in the JupyterLab API.  Instead,
-    # we should just return a 200 with the destination field filled out
-    # with a path relative to the notebook dir, which we can assume to
-    # be ${HOME}, and let the UI extension handle opening the file it
-    # finds there.
-    guide = _get_notebook_path(entry.dest)
+    # we should just return a 200 with the destination field filled
+    # out with a path relative to the server root, and let the UI
+    # extension handle opening the file it finds there.
+    guide = _get_notebook_path(dest)
     return _UIGuidance(status_code=200, dest=guide)
 
 

--- a/rsp_jupyter_extensions/handlers/tutorials.py
+++ b/rsp_jupyter_extensions/handlers/tutorials.py
@@ -87,6 +87,13 @@ def _get_homedir() -> Path:
     return Path(homedir)
 
 
+def _get_jupyter_server_root() -> Path:
+    srv_root = os.getenv("FILEBROWSER_ROOT", "home")
+    if srv_root == "root":
+        return Path("/")
+    return _get_homedir()
+
+
 # RSP-specific tutorial locations
 
 
@@ -135,8 +142,8 @@ def _reabsolutize_path(path: Path) -> Path:
         return path
     # We need to re-absolutize it so it doesn't get written to wherever
     # the Lab extension is running from.
-    homedir = _get_homedir()
-    return homedir / path
+    root_dir = _get_jupyter_server_root()
+    return root_dir / path
 
 
 def _copy_content(entry: HierarchyEntry) -> None:
@@ -148,7 +155,8 @@ def _copy_content(entry: HierarchyEntry) -> None:
     # shutil.copy() is a little silly.  If they don't easily fit into
     # memory, something else is wrong.
     #
-    # We're also assuming that relative paths are relative to $HOME.
+    # Relative paths are relative to either / or $HOME, depending on
+    # $FILEBROWSER_ROOT setting (in turn, a Phalanx setting).
     dest = _reabsolutize_path(entry.dest)
     dest.parent.mkdir(exist_ok=True, parents=True)
     if entry.action == Actions.FETCH:
@@ -168,23 +176,20 @@ def _copy_content(entry: HierarchyEntry) -> None:
 
 
 def _check_containment(dest: Path) -> None:
-    homedir = _get_homedir()
-    # We are making the assumption that non-absolute paths are relative
-    # to $HOME.  This is correct for the RSP.
+    root_dir = _get_jupyter_server_root()
     abs_dest = _reabsolutize_path(dest)
     try:
-        _ = abs_dest.relative_to(homedir)
+        _ = abs_dest.relative_to(root_dir)
     except ValueError as exc:
         raise HierarchyError(
-            f"'{abs_dest!s}' is not contained by '{homedir}'"
+            f"'{abs_dest!s}' is not contained by '{root_dir}'"
         ) from exc
 
 
 def _get_notebook_path(dest: Path) -> str:
-    homedir = _get_homedir()
-    # We also assume that JupyterLab is running with --notebook-dir=${HOME}
+    root_dir = _get_jupyter_server_root()
     if dest.is_absolute():
-        return str(dest.relative_to(homedir))
+        return str(dest.relative_to(root_dir))
     return str(dest)
 
 

--- a/rsp_jupyter_extensions/tests/copy_test.py
+++ b/rsp_jupyter_extensions/tests/copy_test.py
@@ -9,7 +9,6 @@ from pyfakefs.fake_filesystem import FakeFilesystem
 from rsp_jupyter_extensions.handlers.tutorials import _copy_and_guide
 from rsp_jupyter_extensions.models.tutorials import (
     HierarchyError,
-    UserEnvironmentError,
 )
 
 
@@ -67,6 +66,29 @@ def test_copy(rsp_fs: FakeFilesystem) -> None:
     assert outf.read_text() == new_contents
 
 
+def test_alternate_root(
+    rsp_fs: FakeFilesystem, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test alternate root dir."""
+    tmp_path = Path(os.environ.get("TMPDIR", "/tmp"))
+    inp = {
+        "menu_name": "hello.txt",
+        "action": "copy",
+        "disposition": "prompt",
+        "parent": "/",
+        "menu_path": "/hello.txt",
+        "src": "/in/hello.txt",
+        "dest": f"{tmp_path}/hello.txt",
+    }
+
+    txt = "Howdy, Prime Material Plane!\n"
+    Path("/in").mkdir()
+    Path("/in/hello.txt").write_text(txt)
+    monkeypatch.setenv("FILEBROWSER_ROOT", "root")
+    _ = _copy_and_guide(inp)
+    assert Path(inp["dest"]).read_text() == txt
+
+
 def test_bad_copy(
     rsp_fs: FakeFilesystem, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -82,14 +104,11 @@ def test_bad_copy(
         "dest": f"{tmp_path}/hello.txt",
     }
 
-    monkeypatch.delenv("HOME")
-    with pytest.raises(
-        UserEnvironmentError, match="home directory is not set"
-    ):
-        _ = _copy_and_guide(inp)
-    monkeypatch.setenv("HOME", "/nowhere")
+    Path("/in").mkdir()
+    Path("/in/hello.txt").write_text("Howdy, Prime Material Plane!\n")
+
     with pytest.raises(
         HierarchyError,
-        match="/hello.txt' is not contained by '/nowhere'",
+        match="/hello.txt' is not contained by '/home/irian'",
     ):
         _ = _copy_and_guide(inp)

--- a/rsp_jupyter_extensions/tests/copy_test.py
+++ b/rsp_jupyter_extensions/tests/copy_test.py
@@ -70,7 +70,6 @@ def test_alternate_root(
     rsp_fs: FakeFilesystem, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test alternate root dir."""
-    tmp_path = Path(os.environ.get("TMPDIR", "/tmp"))
     inp = {
         "menu_name": "hello.txt",
         "action": "copy",
@@ -78,15 +77,19 @@ def test_alternate_root(
         "parent": "/",
         "menu_path": "/hello.txt",
         "src": "/in/hello.txt",
-        "dest": f"{tmp_path}/hello.txt",
+        "dest": "dest/hello.txt",
     }
 
     txt = "Howdy, Prime Material Plane!\n"
     Path("/in").mkdir()
+    Path("/home/irian/dest").mkdir(parents=True)
     Path("/in/hello.txt").write_text(txt)
     monkeypatch.setenv("FILEBROWSER_ROOT", "root")
-    _ = _copy_and_guide(inp)
-    assert Path(inp["dest"]).read_text() == txt
+    cr = _copy_and_guide(inp)
+    assert not Path("/dest/hello.txt").exists()
+    assert Path("/home/irian/dest/hello.txt").read_text() == txt
+    assert cr.status_code == 200
+    assert cr.dest == "home/irian/dest/hello.txt"
 
 
 def test_bad_copy(

--- a/src/query.ts
+++ b/src/query.ts
@@ -454,7 +454,7 @@ export function createSQLCard(sqlQuery: string, title?: string): HTMLElement {
 }
 
 /**
- * Initialization data for the jupyterlab-lsstquery extension.
+ * Initialization data for the query extension.
  */
 const rspQueryExtension: JupyterFrontEndPlugin<void> = {
   activate: activateRSPQueryExtension,

--- a/src/tutorials.ts
+++ b/src/tutorials.ts
@@ -280,7 +280,7 @@ async function overwriteDialog(
     logMessage(LogLevels.DEBUG, cfg, 'Showing overwrite dialog');
     const result: IDialogResult = await showDialog(dialogOptions);
     if (!result) {
-      logMessage(LogLevels.DEBUG, cfg, 'No result from queryDialog');
+      logMessage(LogLevels.DEBUG, cfg, 'No result from overwriteDialog');
       return;
     }
     logMessage(LogLevels.DEBUG, cfg, 'Result from overwriteDialog: ', result);
@@ -428,7 +428,7 @@ export function activateRSPTutorialsExtension(
 }
 
 /**
- * Initialization data for the jupyterlab-lsstquery extension.
+ * Initialization data for the tutorials extension.
  */
 const rspTutorialsExtension: JupyterFrontEndPlugin<void> = {
   activate: activateRSPTutorialsExtension,


### PR DESCRIPTION
FILEBROWSER_ROOT is not currently set and by convention defaults to "home".  It will eventually be a config item rather than an env var, with legal values being a StrEnum either "root" or "home".